### PR TITLE
Update timezonefinder version

### DIFF
--- a/custom_components/arvee/manifest.json
+++ b/custom_components/arvee/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "assumed_state",
   "name": "Arvee",
   "requirements": [
-    "timezonefinder==6.1.9"
+    "timezonefinder==6.4.1"
   ],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
Latest Home Assistant Core 2024.2.x includes Python 3.12 (https://www.home-assistant.io/blog/2024/02/07/release-20242/#shipping-on-a-new-python-version)

timezonefinder supports Python 3.12 as of version 6.4.0.

Need to update the timezonefinder requirement to 6.4.0 or greater to install on the latest Home Assistant.

**However, the installation currently fails as there is an issue with the h3 dependency**. Some users have had success with Python 3.12.1, but Home Assistant 2024.2.0 and 2024.2.1 fails with the error:
`Unable to install package timezonefinder==6.4.1: error: subprocess-exited-with-error × Building wheel for h3 (pyproject.toml) did not run successfully. │ exit code: 1 ╰─> [11 lines of output] Traceback (most recent call last): File "/tmp/pip-build-env-w4bn3qf6/overlay/lib/python3.12/site-packages/skbuild/setuptools_wrap.py", line 645, in setup cmkr = cmaker.CMaker(cmake_executable) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/tmp/pip-build-env-w4bn3qf6/overlay/lib/python3.12/site-packages/skbuild/cmaker.py", line 148, in __init__ self.cmake_version = get_cmake_version(self.cmake_executable) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/tmp/pip-build-env-w4bn3qf6/overlay/lib/python3.12/site-packages/skbuild/cmaker.py", line 105, in get_cmake_version raise SKBuildError(msg) from err Problem with the CMake installation, aborting build. CMake executable is /tmp/pip-build-env-w4bn3qf6/overlay/lib/python3.12/site-packages/cmake/data/bin/cmake [end of output] note: This error originates from a subprocess, and is likely not a problem with pip. ERROR: Failed building wheel for h3 ERROR: Could not build wheels for h3, which is required to install pyproject.toml-based projects
`

Wait to merge PR until this is resolved. Related project issues:
https://github.com/uber/h3-py/issues/342
https://github.com/uber/h3-py/issues/326
https://github.com/jannikmi/timezonefinder/issues/208

Workaround by switching to timeapi.io in the meantime (or permanently if acceptable to depend on the cloud). Working install for Home Assistant 2024.2.1 is in PR #5.