### PR TITLE
Switch to Timeapi.io (depends on the cloud)

### DIFF
--- a/custom_components/arvee/__init__.py
+++ b/custom_components/arvee/__init__.py
@@ -2,7 +2,7 @@ import homeassistant.core as ha
 
 import voluptuous as vol
 
-from timezonefinder import TimezoneFinder
+import aiohttp
 from homeassistant import core
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_register_admin_service
@@ -20,9 +20,11 @@ async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:
 
     async def async_set_timezone_geo(call: ha.ServiceCall) -> None:
         """Service handler to set timezone by lat/lng"""
-        tzf = TimezoneFinder()
-        result = tzf.timezone_at(lat=call.data[ATTR_LATITUDE], lng=call.data[ATTR_LONGITUDE])
-
+        async with aiohttp.ClientSession() as session:
+            async with session.get("https://timeapi.io/api/TimeZone/coordinate", params={"latitude": call.data[ATTR_LATITUDE], "longitude": call.data[ATTR_LONGITUDE]}) as response:
+                json_data = await response.json()
+        result = json_data.get("timeZone")
+        
         if result is None:
             return
 

--- a/custom_components/arvee/manifest.json
+++ b/custom_components/arvee/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "aiohttp"
   ],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/arvee/manifest.json
+++ b/custom_components/arvee/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "assumed_state",
   "name": "Arvee",
   "requirements": [
-    "timezonefinder==6.1.9"
+    "aiohttp"
   ],
   "version": "1.1.0"
 }


### PR DESCRIPTION
(Temporarily?) Workaround timezonefinder build issues by switching to call timeapi.io API. This change will cause this integration to depend on the cloud. See PR #3 for more info.