### PR TITLE
Addition of optional elevation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Home Assistant integration designed for mobile installations (RVs, boats, etc.
 
 - **Automatic Location Tracking**: Configure GPS entities and Arvee automatically updates Home Assistant's home location
 - **Automatic Timezone Updates**: Timezone is automatically determined based on your coordinates using offline lookup
+- **Optional Elevation Support**: Configure an elevation entity to keep Home Assistant's elevation in sync with your GPS altitude
 - **Configurable Threshold**: Set a minimum distance (in miles) before updates are triggered to avoid constant updates
 - **Manual Services**: Services available for manual timezone/location control via automations
 
@@ -37,7 +38,8 @@ A Home Assistant integration designed for mobile installations (RVs, boats, etc.
 2. Click **+ Add Integration**
 3. Search for "Arvee"
 4. Select your latitude and longitude entities (from a GPS tracker, phone, etc.)
-5. Set the update threshold (minimum distance in miles before updating)
+5. Optionally select an elevation entity to track altitude (supports meters or feet with automatic conversion)
+6. Set the update threshold (minimum distance in miles before updating)
 
 ### GPS Entity Sources
 
@@ -65,13 +67,16 @@ Manually set location and timezone based on coordinates.
 |-------|-------------|---------|
 | `latitude` | Latitude coordinate | `40.7128` |
 | `longitude` | Longitude coordinate | `-74.0060` |
+| `elevation` | Elevation value (optional) | `100` |
+| `elevation_unit` | Unit for elevation: `m` (meters) or `ft` (feet). Default: `m` | `ft` |
 
 ## How It Works
 
-1. Arvee monitors the configured latitude/longitude entities for state changes
+1. Arvee monitors the configured latitude/longitude entities (and optionally elevation) for state changes
 2. When a change is detected, it calculates the distance from the last known position
 3. If the distance exceeds the configured threshold, it:
    - Updates Home Assistant's home latitude/longitude
+   - Updates elevation if an elevation entity is configured
    - Looks up the timezone for the new coordinates (using `tzfpy` - fully offline)
    - Updates Home Assistant's timezone
 
@@ -79,6 +84,7 @@ Manually set location and timezone based on coordinates.
 
 - **Timezone Display**: Home Assistant's UI uses friendly names for timezones (e.g., "Eastern Time" for `America/New_York`). If you're in a less common timezone, the dropdown in Settings may appear blank, but the timezone is still correctly set.
 - **Offline Operation**: Timezone lookups are performed entirely offline using the `tzfpy` library - no internet connection required.
+- **Elevation Units**: When using an elevation entity, Arvee automatically detects the unit from the entity's `unit_of_measurement` attribute and converts feet to meters if needed. Home Assistant stores elevation in meters.
 
 ## Troubleshooting
 

--- a/custom_components/arvee/config_flow.py
+++ b/custom_components/arvee/config_flow.py
@@ -26,6 +26,16 @@ _LOGGER = logging.getLogger(__name__)
 def get_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     """Get the config schema with optional defaults."""
     defaults = defaults or {}
+
+    # Only set a default for elevation if one actually exists,
+    # otherwise an empty string default fails EntitySelector validation.
+    elevation_default = defaults.get(CONF_ELEVATION_ENTITY)
+    elevation_key = (
+        vol.Optional(CONF_ELEVATION_ENTITY, default=elevation_default)
+        if elevation_default
+        else vol.Optional(CONF_ELEVATION_ENTITY)
+    )
+
     return vol.Schema({
         vol.Required(
             CONF_LATITUDE_ENTITY,
@@ -39,10 +49,7 @@ def get_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
         ): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "device_tracker", "input_number"]),
         ),
-        vol.Optional(
-            CONF_ELEVATION_ENTITY,
-            default=defaults.get(CONF_ELEVATION_ENTITY, ""),
-        ): selector.EntitySelector(
+        elevation_key: selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "device_tracker", "input_number"]),
         ),
         vol.Optional(

--- a/custom_components/arvee/const.py
+++ b/custom_components/arvee/const.py
@@ -7,6 +7,7 @@ SERVICE_SET_GEO_TIMEZONE = "set_geo_timezone"
 # Config entry keys
 CONF_LATITUDE_ENTITY = "latitude_entity"
 CONF_LONGITUDE_ENTITY = "longitude_entity"
+CONF_ELEVATION_ENTITY = "elevation_entity"
 CONF_UPDATE_THRESHOLD = "update_threshold"
 
 # Defaults
@@ -15,4 +16,11 @@ DEFAULT_UPDATE_THRESHOLD = 10.0  # miles
 # Attributes
 ATTR_LATITUDE = "latitude"
 ATTR_LONGITUDE = "longitude"
+ATTR_ELEVATION = "elevation"
+ATTR_ELEVATION_UNIT = "elevation_unit"
 ATTR_TIMEZONE = "timezone"
+
+# Units
+UNIT_METERS = "m"
+UNIT_FEET = "ft"
+FEET_TO_METERS = 0.3048

--- a/custom_components/arvee/services.yaml
+++ b/custom_components/arvee/services.yaml
@@ -34,3 +34,24 @@ set_geo_timezone:
           min: -180
           max: 180
           mode: box
+    elevation:
+      name: Elevation
+      description: Elevation value (optional). Unit specified by elevation_unit.
+      required: false
+      example: 100
+      selector:
+        number:
+          mode: box
+    elevation_unit:
+      name: Elevation Unit
+      description: Unit for elevation value (m for meters, ft for feet)
+      required: false
+      default: m
+      example: m
+      selector:
+        select:
+          options:
+            - label: Meters
+              value: m
+            - label: Feet
+              value: ft

--- a/custom_components/arvee/strings.json
+++ b/custom_components/arvee/strings.json
@@ -7,11 +7,13 @@
         "data": {
           "latitude_entity": "Latitude Entity",
           "longitude_entity": "Longitude Entity",
+          "elevation_entity": "Elevation Entity (Optional)",
           "update_threshold": "Update Threshold (miles)"
         },
         "data_description": {
           "latitude_entity": "Entity that provides the current latitude (e.g., from a GPS tracker or phone)",
           "longitude_entity": "Entity that provides the current longitude",
+          "elevation_entity": "Entity that provides the current elevation (feet or meters, auto-detected)",
           "update_threshold": "Minimum distance (in miles) before updating location and timezone"
         }
       }
@@ -19,7 +21,8 @@
     "error": {
       "entity_not_found": "Entity not found",
       "invalid_latitude": "Entity does not have a valid numeric latitude value",
-      "invalid_longitude": "Entity does not have a valid numeric longitude value"
+      "invalid_longitude": "Entity does not have a valid numeric longitude value",
+      "invalid_elevation": "Entity does not have a valid numeric elevation value"
     },
     "abort": {
       "already_configured": "Arvee is already configured"
@@ -33,11 +36,13 @@
         "data": {
           "latitude_entity": "Latitude Entity",
           "longitude_entity": "Longitude Entity",
+          "elevation_entity": "Elevation Entity (Optional)",
           "update_threshold": "Update Threshold (miles)"
         },
         "data_description": {
           "latitude_entity": "Entity that provides the current latitude",
           "longitude_entity": "Entity that provides the current longitude",
+          "elevation_entity": "Entity that provides the current elevation (feet or meters, auto-detected)",
           "update_threshold": "Minimum distance (in miles) before updating location and timezone"
         }
       }
@@ -45,7 +50,8 @@
     "error": {
       "entity_not_found": "Entity not found",
       "invalid_latitude": "Entity does not have a valid numeric latitude value",
-      "invalid_longitude": "Entity does not have a valid numeric longitude value"
+      "invalid_longitude": "Entity does not have a valid numeric longitude value",
+      "invalid_elevation": "Entity does not have a valid numeric elevation value"
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,19 @@ async def mock_gps_entities(hass: HomeAssistant):
 
 
 @pytest.fixture
+async def mock_gps_entities_with_elevation(hass: HomeAssistant):
+    """Create mock GPS entities including elevation."""
+    hass.states.async_set("sensor.test_latitude", "40.7128")
+    hass.states.async_set("sensor.test_longitude", "-74.0060")
+    hass.states.async_set("sensor.test_elevation", "100")
+    return {
+        "latitude": "sensor.test_latitude",
+        "longitude": "sensor.test_longitude",
+        "elevation": "sensor.test_elevation",
+    }
+
+
+@pytest.fixture
 async def mock_gps_entities_invalid(hass: HomeAssistant):
     """Create mock GPS entities with invalid values."""
     hass.states.async_set("sensor.test_latitude", "unknown")
@@ -41,4 +54,17 @@ async def mock_gps_entities_invalid(hass: HomeAssistant):
     return {
         "latitude": "sensor.test_latitude",
         "longitude": "sensor.test_longitude",
+    }
+
+
+@pytest.fixture
+async def mock_gps_entities_invalid_elevation(hass: HomeAssistant):
+    """Create mock GPS entities with invalid elevation."""
+    hass.states.async_set("sensor.test_latitude", "40.7128")
+    hass.states.async_set("sensor.test_longitude", "-74.0060")
+    hass.states.async_set("sensor.test_elevation", "unknown")
+    return {
+        "latitude": "sensor.test_latitude",
+        "longitude": "sensor.test_longitude",
+        "elevation": "sensor.test_elevation",
     }


### PR DESCRIPTION
Summary of changes:

Add optional elevation entity tracking that keeps Home Assistant's elevation in sync with GPS altitude
Automatically detect elevation units from the entity's unit_of_measurement attribute and convert feet to meters
Add elevation parameters to the set_geo_timezone service for manual control

Tests have been added to check for support with and without elevation from both the config flow as well as the set_geo_timezone service.